### PR TITLE
Rounding in quickpath

### DIFF
--- a/src/zerog/util/grisu/Grisu.java
+++ b/src/zerog/util/grisu/Grisu.java
@@ -259,7 +259,7 @@ public class Grisu {
 
             // n div 10^x = n div 2^x div 5^x
             // can't just divide because of sign bit
-            int pow10 = (int)CachedPowers.u_pow10[digits - 1];
+            long pow10 = CachedPowers.u_pow10[digits - 1];
             int u_dig = (int)((u_intpart >>> digits - 1) / (pow10 >>> digits - 1));  
             
             u_intpart = u_intpart - (u_dig * pow10);

--- a/src/zerog/util/grisu/Grisu.java
+++ b/src/zerog/util/grisu/Grisu.java
@@ -201,6 +201,17 @@ public class Grisu {
         assert u_vinteger != 0;
         
         int ndigits = CachedPowers.numUnsignedLongDigits( u_vinteger );
+		int rounded = 0;
+        
+		for (; ndigits > max_grisu_precision; ndigits--, rounded++) {
+			long u_vinteger_div10 = (u_vinteger >>> 1) / 5;
+			int u_vinteger_mod10 = (int) (u_vinteger - u_vinteger_div10 * 10);
+
+			u_vinteger = u_vinteger_div10;
+			if (u_vinteger_mod10 >= 5) {
+				u_vinteger++;
+			}
+		}
 
         for( int i = 0; i < ndigits; ++i ) {
             
@@ -213,7 +224,7 @@ public class Grisu {
             u_vinteger = u_vinteger_div10;
         }
                 
-        return StuffedPair.cons( ndigits, 0 );
+		return StuffedPair.cons(ndigits, rounded);
     }
 
     protected static void round( byte[] buffer, int pos, long u_delta, long u_rest, long  u_onef, long u_winf ) {

--- a/test/zerog/util/grisu/GrisuTest.java
+++ b/test/zerog/util/grisu/GrisuTest.java
@@ -9,7 +9,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 public class GrisuTest {
-
     @Test
     public void test_zero() {
         double d = 0.0;
@@ -283,5 +282,12 @@ public class GrisuTest {
 		double d = -3.1781265513747738E18;
 		String s = Grisu.fmt.doubleToString(d);
 		assertEquals("-3.1781265513747738e+18", s);
+	}
+	
+	@Test
+	public void test_longpow10() {
+		double d = 3.6445917645030247E-267;
+		String s = Grisu.fmt.doubleToString(d);
+		assertEquals("3.6445917645030247e-267", s);
 	}
 }

--- a/test/zerog/util/grisu/GrisuTest.java
+++ b/test/zerog/util/grisu/GrisuTest.java
@@ -1,7 +1,11 @@
 package zerog.util.grisu;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class GrisuTest {
@@ -273,4 +277,11 @@ public class GrisuTest {
         String s = Grisu.fmt.doubleToString( d );
         assertEquals("502973.0", s);
     }
+    
+	@Test
+	public void test_fastpath_rounding() {
+		double d = -3.1781265513747738E18;
+		String s = Grisu.fmt.doubleToString(d);
+		assertEquals("-3.1781265513747738e+18", s);
+	}
 }


### PR DESCRIPTION
In case of quickpath printing it is needed to round digits after the 17th not to have a buffer overflow in accessing the printing buffer. A test case is provided for regression.
